### PR TITLE
chore(deps): restrict aws provider version to < 6.0.0

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 4.9.0, < 6.0.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -55,7 +55,7 @@ spec:
 
     - component: "eks/cert-manager"
       source: github.com/cloudposse-terraform-components/aws-eks-cert-manager.git//src?ref={{.Version}}
-      version: v1.535.1
+      version: v1.536.2
       targets:
         - "components/terraform/eks/cert-manager"
       included_paths:


### PR DESCRIPTION
This pull request includes a version constraint update for the AWS provider in the Terraform configuration file `src/versions.tf`. The change ensures compatibility with versions up to but not including 6.0.0.

* `src/versions.tf`: Updated the version constraint for the `aws` provider to `>= 4.9.0, < 6.0.0` to ensure compatibility with future versions while avoiding potential breaking changes in version 6.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated AWS provider version constraints to allow versions from 4.9.0 up to, but not including, 6.0.0.
  * Upgraded the version of the "eks/cert-manager" component to enhance stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->