### PR TITLE
chore(deps): restrict helm provider version to ~ 2.0.0

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.0"
+      version = "~> 2.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This pull request includes a version constraint update for the Helm provider in the Terraform configuration file `src/versions.tf`. The change ensures compatibility with versions up to but not including 3.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Helm provider version constraint to allow only compatible 2.x versions in the Terraform configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->