### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- migrate Renovate from the deprecated `config:base` preset to `config:recommended`
- preserve the existing `prConcurrentLimit: 5` setting

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

Note: I did not run `atmos test run` because the repo guidance says the Terratest suite deploys AWS resources and may incur cost; this PR only changes Renovate configuration.

Closes #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use a more comprehensive preset for improved handling of dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->